### PR TITLE
Add linting GitHub Action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,5 @@ jobs:
           extra-packages: styler, local::.
 
       - name: Style
-        run: styler::style_pkg(transform = FALSE)
+        run: styler::style_pkg(dry = "fail")
         shell: Rscript {0}
-        env:
-          STYLER_ERROR_ON_CHANGE: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,26 @@
+
+name: lint
+
+on: [push, pull_request]
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: styler, local::.
+
+      - name: Style
+        run: styler::style_pkg(transform = FALSE)
+        shell: Rscript {0}
+        env:
+          STYLER_ERROR_ON_CHANGE: true


### PR DESCRIPTION
This PR introduces a GitHub Action that runs `styler::style_pkg(dry = "fail")` on pushes and pull requests. It throws an error if `styler` would make changes to the code.

Closes issue #5.