### PR TITLE
Retain 'bad' genes if desired

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Imports:
     stats,
     utils,
     rappdirs
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Suggests: 
     knitr,
     rmarkdown,

--- a/R/convert.R
+++ b/R/convert.R
@@ -112,6 +112,8 @@ which_frm_cols <- function(df, frm, frm_cols = NULL, verbose = TRUE) {
 #' **Behavioral Notes**
 #' - If a gene name cannot be mapped, it is replaced with `NA` and a warning is
 #' raised.
+#' - If ``bad_genes_col = TRUE``, appends a 'bad_genes' column containing
+#' comma-separated gene names that could not be converted for each row.
 #' - If `frm` is `'imgt'` and `frm_cols` is not provided, 10X column
 #' names are assumed.
 #' - Constant (C) genes are set to `NA` when converting to Adaptive formats,
@@ -138,6 +140,8 @@ which_frm_cols <- function(df, frm, frm_cols = NULL, verbose = TRUE) {
 #' @param frm_cols A character vector of custom gene column names.
 #' Optional; defaults to `NULL`.
 #' @param verbose A boolean, whether to display messages. Optional; defaults to `TRUE`.
+#' @param bad_genes_col A boolean, whether to add a column of the
+#' unconvertable genes. Defaults to ``FALSE``.
 #'
 #' @return A dataframe with converted TCR gene names.
 #' @autoglobal
@@ -147,7 +151,8 @@ which_frm_cols <- function(df, frm, frm_cols = NULL, verbose = TRUE) {
 #' df <- read.csv(tcr_file)[c("barcode", "v_gene", "j_gene", "cdr3")]
 #' df
 #' convert_gene(df, "tenx", "adaptive", verbose = FALSE)
-convert_gene <- function(df, frm, to, species = "human", frm_cols = NULL, verbose = TRUE) {
+convert_gene <- function(df, frm, to, species = "human", frm_cols = NULL,
+                         verbose = TRUE, bad_genes_col = FALSE) {
   if (frm == to) {
     stop('"frm" and "to" formats should be different.')
   }
@@ -180,11 +185,25 @@ convert_gene <- function(df, frm, to, species = "human", frm_cols = NULL, verbos
   new_genes <- list()
   bad_genes_all <- c()
 
+  # Make empty dataframe that has same index/rownames as input dataframe
+  if (bad_genes_col) {
+    bad_df <- data.frame(row.names = rownames(df))
+  }
+
+
   for (col in cols_from) {
     if (col %in% colnames(df)) {
       merged <- merge(df[, c(col, "id"), drop = FALSE], lookup, by.x = col, by.y = frm, all.x = TRUE)
       merged <- merged[order(merged$id), ]
       good_genes <- merged[, to]
+
+      if (bad_genes_col) {
+        # Keep bad genes and make good genes NA
+        # Note that when good_genes is NA, it means there was no match in the
+        # lookup table, so the original gene is "bad"
+        bad_df[[col]] <- ifelse(is.na(good_genes), df[[col]], NA)
+      }
+
       # Note genes where the merge produced an NA on the 'to' format side
       new_bad_genes <- merged[is.na(merged[, to]), col]
       # We don't expect the entire column of genes to be empty.
@@ -212,6 +231,21 @@ convert_gene <- function(df, frm, to, species = "human", frm_cols = NULL, verbos
     df_out[, col] <- new_genes[[col]]
     df_out[[col]][df_out[[col]] == "NoData"] <- NA_character_
   }
+
+  if (bad_genes_col) {
+    # Append the column of bad genes
+    # For each row, concatenate non-NA values with commas and store in the
+    # 'bad_genes' column
+    df_out$bad_genes <- apply(bad_df, 1, function(row) {
+      non_na <- row[!is.na(row)]
+      if (length(non_na) > 0) {
+        paste(non_na, collapse = ",")
+      } else {
+        NA_character_
+      }
+    })
+  }
+
   df_out <- subset(df_out, select = -c(id)) # Remove row number column
 
   df_out

--- a/man/convert_gene.Rd
+++ b/man/convert_gene.Rd
@@ -4,7 +4,15 @@
 \alias{convert_gene}
 \title{Convert gene names}
 \usage{
-convert_gene(df, frm, to, species = "human", frm_cols = NULL, verbose = TRUE)
+convert_gene(
+  df,
+  frm,
+  to,
+  species = "human",
+  frm_cols = NULL,
+  verbose = TRUE,
+  bad_genes_col = FALSE
+)
 }
 \arguments{
 \item{df}{A dataframe containing TCR gene names.}
@@ -21,6 +29,9 @@ convert_gene(df, frm, to, species = "human", frm_cols = NULL, verbose = TRUE)
 Optional; defaults to \code{NULL}.}
 
 \item{verbose}{A boolean, whether to display messages. Optional; defaults to \code{TRUE}.}
+
+\item{bad_genes_col}{A boolean, whether to add a column of the
+unconvertable genes. Defaults to \code{FALSE}.}
 }
 \value{
 A dataframe with converted TCR gene names.
@@ -41,6 +52,8 @@ genes in all three formats.
 \itemize{
 \item If a gene name cannot be mapped, it is replaced with \code{NA} and a warning is
 raised.
+\item If \code{bad_genes_col = TRUE}, appends a 'bad_genes' column containing
+comma-separated gene names that could not be converted for each row.
 \item If \code{frm} is \code{'imgt'} and \code{frm_cols} is not provided, 10X column
 names are assumed.
 \item Constant (C) genes are set to \code{NA} when converting to Adaptive formats,

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -304,3 +304,50 @@ test_that("convert_gene verbose flag works", {
     captured_warnings
   )))
 })
+
+
+test_that("bad_genes_col flag works", {
+  # Test dataframe with some genes that won't convert
+  tenx_df_bad <- data.frame(
+    v_gene = c("TRAV12-1", "BAD_V_GENE"),
+    d_gene = c(NA, "TRBD1"),
+    j_gene = c("TRAJ16", "BAD_J_GENE"),
+    c_gene = c("BAD_C_GENE", "TRBC2"),
+    cdr3 = c("CAVLIF", "CASSGF")
+  )
+
+  # Expected output with bad_genes_col=TRUE
+  expected_with_bad <- data.frame(
+    v_gene = c("TRAV12-1*01", NA),
+    d_gene = c(NA, "TRBD1*01"),
+    j_gene = c("TRAJ16*01", NA),
+    c_gene = c(NA, "TRBC2*01"),
+    cdr3 = c("CAVLIF", "CASSGF"),
+    bad_genes = c("BAD_C_GENE", "BAD_V_GENE,BAD_J_GENE")
+  )
+
+  # Expected output with bad_genes_col=FALSE
+  expected_without_bad <- data.frame(
+    v_gene = c("TRAV12-1*01", NA),
+    d_gene = c(NA, "TRBD1*01"),
+    j_gene = c("TRAJ16*01", NA),
+    c_gene = c(NA, "TRBC2*01"),
+    cdr3 = c("CAVLIF", "CASSGF")
+  )
+
+  suppressWarnings({
+    # Test with bad_genes_col=TRUE
+    result_with <- convert_gene(
+      tenx_df_bad, "tenx", "imgt",
+      bad_genes_col = TRUE, verbose = FALSE
+    )
+    expect_equal(result_with, expected_with_bad)
+
+    # Test with bad_genes_col=FALSE
+    result_without <- convert_gene(
+      tenx_df_bad, "tenx", "imgt",
+      bad_genes_col = FALSE, verbose = FALSE
+    )
+    expect_equal(result_without, expected_without_bad)
+  })
+})

--- a/vignettes/articles/faq.Rmd
+++ b/vignettes/articles/faq.Rmd
@@ -11,30 +11,30 @@ knitr::opts_chunk$set(
 
 ## How does TCRconvertR work?
 
-TCRconvertR essentially performs a `merge` between the input data and a 
-lookup table that includes the naming conventions for each gene. 
-These lookup tables are constructed from IMGT reference FASTA files and account 
-for the specific naming peculiarities of each platform. The built-in lookup tables 
+TCRconvertR essentially performs a `merge` between the input data and a
+lookup table that includes the naming conventions for each gene.
+These lookup tables are constructed from IMGT reference FASTA files and account
+for the specific naming peculiarities of each platform. The built-in lookup tables
 are located under `inst/extdata/`.
 
-TCRconvert performs a `merge` between the input data and a lookup table that 
-includes gene names with each nomenclature. These lookup tables are constructed 
-from IMGT reference FASTA files and account for the specific naming peculiarities 
-of each platform. The built-in lookup tables are located under `inst/extdata/`. 
-The code used to build the lookup tables, which demonstrates the conversion logic, is 
-within the [build_lookup_from_fastas](https://github.com/seshadrilab/tcrconvert/blob/361f930d598996f3fa239a715c829ad8c107c63e/tcrconvert/build_lookup.py#L196) function.
+TCRconvert performs a `merge` between the input data and a lookup table that
+includes gene names with each nomenclature. These lookup tables are constructed
+from IMGT reference FASTA files and account for the specific naming peculiarities
+of each platform. The built-in lookup tables are located under `inst/extdata/`.
+The code used to build the lookup tables, which demonstrates the conversion logic, is
+within the `build_lookup_from_fastas` function in the `convert.R` script.
 
 
 ## What input columns are required?
 
-TCRconvertR expects at least one V, D, J, and/or C gene column. You can use standard 
+TCRconvertR expects at least one V, D, J, and/or C gene column. You can use standard
 10X and Adaptive column names or custom names.
 
 
 ## What if I have missing genes?
 
-`NA` values in the input dataframe will remain `NA` in the output. Genes that 
-are not found in the lookup table (which is based on the IMGT reference), will be 
+`NA` values in the input dataframe will remain `NA` in the output. Genes that
+are not found in the lookup table (which is based on the IMGT reference), will be
 converted to `NA`. The built-in lookup tables are located under `inst/extdata/`.
 
 
@@ -50,25 +50,25 @@ Since 10X does not provide allele-level information, all genes are assigned the 
 
 ## How are C genes converted to Adaptive?
 
-Adaptive does not capture constant ("C") gene information. If converting to the 
+Adaptive does not capture constant ("C") gene information. If converting to the
 Adaptive format, all C genes will be set to `NA`.
 
 
 ## What column names should I use for my IMGT-formatted data?
 
-IMGT does not have standard column names, so it's assumed that the 10X names 
-are used: c(`v_gene`, `d_gene`, `j_gene`, `c_gene`). To use other names, 
+IMGT does not have standard column names, so it's assumed that the 10X names
+are used: c(`v_gene`, `d_gene`, `j_gene`, `c_gene`). To use other names,
 specify them as a character vector with `frm_cols`.
 
 ## Can I input AIRR files?
 
-Yes, just specify the AIRR column names c(`v_call`, `d_call`, `j_call`, `c_call`) using `frm_cols`. 
+Yes, just specify the AIRR column names c(`v_call`, `d_call`, `j_call`, `c_call`) using `frm_cols`.
 You must still specify the input naming convention with `frm` (usually `'imgt'`).
 
 
 ## What if I have custom column names?
 
-If you're using non-standard column names that do not match 10X, Adaptive, or 
+If you're using non-standard column names that do not match 10X, Adaptive, or
 Adaptive V2 formats, specify them with `frm_cols`.
 
 
@@ -79,12 +79,21 @@ Gene names containing "OR" or "DV" are accounted for in the lookup tables.
 Combinations of gene names, like `TCRAV01-02/12-02`, will be converted to `NA` because they are not in the IMGT reference.
 
 
+## What about genes that aren't the reference?
+
+A warning message always lists all unique genes that could not be converted.
+
+Genes not in the reference are replaced with NA in the converted columns by default.
+If ``bad_genes_col = TRUE``, the original unconverted gene names are retained in a
+'bad_genes' column that contains the comma-separated 'bad' names for each row.
+
+
 ## Are non-human species supported?
 
-Mouse and rhesus macaque are supported out-of-the-box. For other species, see 
-"Using a custom reference" in the usage pages. 
+Mouse and rhesus macaque are supported out-of-the-box. For other species, see
+"Using a custom reference" in the usage pages.
 
-The rhesus and mouse lookup tables were built from IMGT reference FASTAs and 
+The rhesus and mouse lookup tables were built from IMGT reference FASTAs and
 gene tables. Mouse genes cover both "Mouse" and "Mouse C57BL/6J" as listed in IMGT.
 
 


### PR DESCRIPTION
This PR adds a parameter (`bad_genes_col`) to the `convert_gene()` function that allows a user to retain unconvertable gene names in an extra column (`bad_genes`) that gets appended to the output data frame.

I added a test for this and documented within the roxygen2 section and FAQ page.

Fixes #22