### PR TITLE
Strip NAs from bad_genes_all before checking length

### DIFF
--- a/R/convert.R
+++ b/R/convert.R
@@ -217,11 +217,11 @@ convert_gene <- function(df, frm, to, species = "human", frm_cols = NULL,
   }
 
   # Display genes we couldn't convert
-  if (!all(is.na(bad_genes_all))) {
-    bad_genes <- unique(bad_genes_all)
+  bad_genes <- unique(bad_genes_all[!is.na(bad_genes_all)])
+  if (length(bad_genes) > 0) {
     warning(paste(
       "These genes are not in IMGT for this species and will be replaced with NA:\n",
-      paste(unique(bad_genes), collapse = ", ")
+      paste(bad_genes, collapse = ", ")
     ))
   }
 

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -306,6 +306,18 @@ test_that("convert_gene verbose flag works", {
 })
 
 
+test_that("NA gene values do not trigger a bad-genes warning", {
+  adapt_v2_df <- data.frame(
+    vMaxResolved = c("TCRAV12-01*01", NA),
+    jMaxResolved = c("TCRAJ16-01*01", NA),
+    aminoAcid = c("CAVLIF", NA)
+  )
+  suppressMessages({
+    expect_no_warning(convert_gene(adapt_v2_df, "adaptivev2", "imgt", verbose = FALSE))
+  })
+})
+
+
 test_that("bad_genes_col flag works", {
   # Test dataframe with some genes that won't convert
   tenx_df_bad <- data.frame(


### PR DESCRIPTION
Basically, my understanding of `NA`s in R must be incomplete, because the condition `!all(is.na(bad_genes_all))` could still produce `TRUE` even if `bad_genes_all` only contains `NA`s from legitimate `NA` rows. Stripping out the `NA`s first and then checking the vector's length works better. The goal is to only print a warning message if there is at least one non-`NA` value in that vector.

Fixes #21 